### PR TITLE
disable optimize property access in release profile

### DIFF
--- a/config.js
+++ b/config.js
@@ -102,6 +102,7 @@ profiles.release = extend(true, {}, config, {
                     dead_code: true,
                     drop_console: true,
                     drop_debugger: true,
+                    properties: false,
                     pure_funcs: [
                         // todo: check and rework this list
                         'debug.assert', 'debug.log', 'debug.info', 'debug.warn', 'debug.fail', 'debug.inspect',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "spa-plugin-webpack",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Compile all CommonJS modules into a single JavaScript file.",
     "author": {
         "name": "Stanislav Kalashnik",


### PR DESCRIPTION
Prevent optimize property names:   a["foo"] → a.foo
